### PR TITLE
Disable submit button if text clears on submission in the slack text …

### DIFF
--- a/Source/Classes/SLKTextViewController.m
+++ b/Source/Classes/SLKTextViewController.m
@@ -693,6 +693,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
     if (self.shouldClearTextAtRightButtonPress) {
         // Clears the text and the undo manager
         [self.textView slk_clearText:YES];
+        self.rightButton.enabled = false;        
     }
     
     // Clears cache


### PR DESCRIPTION
…view controller.

https://weddingwire.atlassian.net/browse/WWIOS-1064

fixes an issue where the submit button was still clickable after submitting a comment because the text was set to autoclear but the button was still enabled. I kinda went back and forth on putting this code in here vs in our actual forums code. It may make the SlackTVC a bit less generic, I think, but it seemed to belong.
